### PR TITLE
RNCWebview conflict patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-webview": "*"
   },
   "dependencies": {
-    "prop-types": "^15.6.2",
-    "react-native-webview": ">=6.0.2"
+    "prop-types": "^15.6.2"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
There is a conflict with React Native Webview when a project has it installed is causes a conflict

Solution is to Move 

```
  "dependencies": {
    "react-native-webview": ">=6.0.2"
  },
```

to 

```
  "peerDependencies": {
    "react-native-webview": "*"
  },