### PR TITLE
docs: Corrected Merchant piblic key typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Easily implement Flutterwave for payments in your React Native appliction. This 
   - [Installation](#installation)
   - [Dependencies](#dependencies)
   - [Activity Indicator (Android)](#activity-indicator-only-needed-for-android)
-  - [Merchant Piblic Key](#fire-merchant-public-key-fire)
+  - [Merchant Public Key](#fire-merchant-public-key-fire)
   - [Important Information](#fire-important-information-fire)
 - Usage
   - [PayWithFlutterwave ](#flutterwave-button)


### PR DESCRIPTION
There's a type in the T.O.C that say's 'Merchane Piblic Key' instead of "Merchant Public Key" ... This PR fixes that :)